### PR TITLE
fix errors caused by rggen/rggen-core update

### DIFF
--- a/lib/rggen/systemverilog/common/utility/identifier.rb
+++ b/lib/rggen/systemverilog/common/utility/identifier.rb
@@ -76,8 +76,8 @@ module RgGen
           def __serialized_lsb__(array_index, lsb)
             index =
               array_index
-                .yield_self(&method(:__serialized_index__))
-                .yield_self(&method(:__enclose_index_in_parenthesis))
+                .then(&method(:__serialized_index__))
+                .then(&method(:__enclose_index_in_parenthesis))
             array_lsb = __reduce_array__([@width, index], :*, 1)
             __reduce_array__([array_lsb, lsb], :+, 0)
           end
@@ -87,7 +87,7 @@ module RgGen
               .reverse
               .zip(__index_factors__)
               .map { |i, f| __calc_index_value__(i, f) }
-              .yield_self { |values| __reduce_array__(values.reverse, :+, 0) }
+              .then { |values| __reduce_array__(values.reverse, :+, 0) }
           end
 
           def __enclose_index_in_parenthesis(index)

--- a/lib/rggen/systemverilog/rtl/bit_field/type/w0crs_w0src_w1crs_w1src_wcrs_wsrc.rb
+++ b/lib/rggen/systemverilog/rtl/bit_field/type/w0crs_w0src_w1crs_w1src_wcrs_wsrc.rb
@@ -20,7 +20,7 @@ RgGen.define_list_item_feature(
     end
 
     def read_set?
-      [:w0crs, :w1crs, :wcrs].include?(bit_field.type)
+      [:w0crs, :w1crs, :wcrs].any? { |type| bit_field.type == type }
     end
 
     def write_action

--- a/lib/rggen/systemverilog/rtl/register_index.rb
+++ b/lib/rggen/systemverilog/rtl/register_index.rb
@@ -51,9 +51,9 @@ module RgGen
 
         def index(offset_or_offsets = nil)
           offset_or_offsets
-            .yield_self(&method(:index_operands))
-            .yield_self(&method(:partial_sums))
-            .yield_self(&method(:reduce_indices))
+            .then(&method(:index_operands))
+            .then(&method(:partial_sums))
+            .then(&method(:reduce_indices))
         end
 
         def inside_loop?

--- a/lib/rggen/systemverilog/rtl/register_type.rb
+++ b/lib/rggen/systemverilog/rtl/register_type.rb
@@ -27,8 +27,8 @@ module RgGen
         def offset_address
           [*register_files, register]
             .flat_map(&method(:collect_offsets))
-            .yield_self(&method(:partial_sums))
-            .yield_self(&method(:format_offsets))
+            .then(&method(:partial_sums))
+            .then(&method(:format_offsets))
         end
 
         def collect_offsets(component)


### PR DESCRIPTION
This PR is to fix errors caused by rggen/rggen-core@4ec870fa6aa05c6c549e0434447f08549332a76b.

rggen/rggen#100
